### PR TITLE
fix millisecond vs microsecond bug

### DIFF
--- a/lib/logger.ex
+++ b/lib/logger.ex
@@ -1,19 +1,29 @@
 defmodule ExLogger do
-  def format(level, message, timestamp, metadata) do
-    try do
-      time = case Timex.format(timestamp, "{ISO:Extended:Z}") do
-        {:ok, time_str} -> time_str
-        _ -> Timex.format!(Timex.now, "{ISO:Extended:Z}")
-      end
-      log_data = Map.merge(%{
-        "msg" => "#{message}",
-        "level" => level,
-        "ts" => time
-      }, Map.new(metadata))
+  alias ExLogger.Formatter.Timestamp
 
-      "#{Poison.encode!(log_data)}\n"
-    rescue
-      _ -> "#{timestamp} #{metadata[level]} #{level} #{message}\n"
-    end
+  @spec format(
+          Logger.level(),
+          Logger.message(),
+          Logger.Formatter.time(),
+          Logger.Formatter.keyword()
+        ) :: IO.chardata()
+  def format(level, message, timestamp, metadata) do
+    offset = Timestamp.utc_offset(Application.fetch_env!(:logger, :utc_log))
+    time = Timestamp.format(timestamp, offset)
+
+    log_data =
+      Map.merge(
+        %{
+          "msg" => "#{message}",
+          "level" => level,
+          "ts" => time
+        },
+        Map.new(metadata)
+      )
+
+    "#{Poison.encode!(log_data)}\n"
+  rescue
+    _ ->
+      "#{Timestamp.format(timestamp, {0, 0})} #{metadata[level]} #{level} #{message}\n"
   end
 end

--- a/lib/timestamp_formatter.ex
+++ b/lib/timestamp_formatter.ex
@@ -1,0 +1,44 @@
+defmodule ExLogger.Formatter.Timestamp do
+  @spec utc_offset(boolean) :: {-23..23, -59..59}
+  def utc_offset(true), do: {0, 0}
+
+  def utc_offset(false) do
+    now = :os.timestamp()
+    offset(:calendar.now_to_universal_time(now), :calendar.now_to_local_time(now))
+  end
+
+  @spec offset(Logger.Formatter.time(), Logger.Formatter.time()) :: {-23..23, -59..59}
+  def offset(utc, local) do
+    case :calendar.time_difference(utc, local) do
+      {0, {h, m, _}} -> {h, m}
+      {-1, {h, 0, _}} -> {h - 24, 0}
+      {-1, {h, m, _}} -> {h - 23, m - 60}
+    end
+  end
+
+  @spec format(Logger.Formatter.time(), {integer, integer}) :: String.t()
+  def format({date, time}, utc_offset) do
+    date =
+      date
+      |> Logger.Formatter.format_date()
+      |> List.to_string()
+
+    time =
+      time
+      |> Logger.Formatter.format_time()
+      |> List.to_string()
+
+    timezone = format_offset(utc_offset)
+
+    "#{date}T#{time}#{timezone}"
+  end
+
+  @spec format_offset({integer, integer}) :: String.t()
+  def format_offset({0, 0}), do: "Z"
+  def format_offset({h, m}) when h > 0 or m > 0, do: "+#{pad(h)}:#{pad(m)}"
+  def format_offset({h, m}) when h < 0 or m < 0, do: "-#{pad(abs(h))}:#{pad(abs(m))}"
+
+  @spec pad(integer) :: String.t()
+  defp pad(int) when int < 10, do: "0#{int}"
+  defp pad(int), do: "#{int}"
+end

--- a/mix.exs
+++ b/mix.exs
@@ -9,8 +9,8 @@ defmodule ExLogger.Mixfile do
       app: :exlogger,
       version: @version,
       elixir: "~> 1.5",
-      start_permanent: Mix.env == :prod,
-      build_embedded: Mix.env == :prod,
+      start_permanent: Mix.env() == :prod,
+      build_embedded: Mix.env() == :prod,
       deps: deps(),
       package: package(),
       description: "JSON log formatter for the elixir Logger",
@@ -23,14 +23,13 @@ defmodule ExLogger.Mixfile do
 
   def application do
     [
-      extra_applications: [:timex, :poison, :logger]
+      extra_applications: [:poison, :logger]
     ]
   end
 
   defp deps do
     [
-      {:poison, "~> 3.1"},
-      {:timex, "~> 3.0"},
+      {:poison, "~> 4.0"},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,14 +1,5 @@
-%{"certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], [], "hexpm"},
-  "combine": {:hex, :combine, "0.10.0", "eff8224eeb56498a2af13011d142c5e7997a80c8f5b97c499f84c841032e429f", [:mix], [], "hexpm"},
+%{
   "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.2", "993e0a95e9fbb790ac54ea58e700b45b299bd48bc44b4ae0404f28161f37a83e", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "gettext": {:hex, :gettext, "0.14.0", "1a019a2e51d5ad3d126efe166dcdf6563768e5d06c32a99ad2281a1fa94b4c72", [:mix], [], "hexpm"},
-  "hackney": {:hex, :hackney, "1.11.0", "4951ee019df102492dabba66a09e305f61919a8a183a7860236c0fde586134b6", [:rebar3], [{:certifi, "2.0.0", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "5.1.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
-  "idna": {:hex, :idna, "5.1.0", "d72b4effeb324ad5da3cab1767cb16b17939004e789d8c0ad5b70f3cea20c89a", [:rebar3], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
-  "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
-  "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},
-  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
-  "timex": {:hex, :timex, "3.1.25", "6002dae5432f749d1c93e2cd103eb73cecb53e50d2c885349e8e4146fc96bd44", [:mix], [{:combine, "~> 0.10", [hex: :combine, repo: "hexpm", optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, repo: "hexpm", optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm"},
-  "tzdata": {:hex, :tzdata, "0.5.16", "13424d3afc76c68ff607f2df966c0ab4f3258859bbe3c979c9ed1606135e7352", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
-  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"}}
+  "poison": {:hex, :poison, "4.0.1", "bcb755a16fac91cad79bfe9fc3585bb07b9331e50cfe3420a24bcc2d735709ae", [:mix], [], "hexpm"},
+}

--- a/test/logger_test.exs
+++ b/test/logger_test.exs
@@ -1,14 +1,41 @@
-defmodule ExLoggerTest do
+defmodule ExLogger.LoggerTest do
   use ExUnit.Case
   doctest ExLogger
 
-  test "greets the world" do
-    timestamp = DateTime.utc_now
-    json = ExLogger.format("info", "hello world!", timestamp, [])
-    assert json != ""
-    assert json == "{\"ts\":\"#{Timex.format!(timestamp, "{ISO:Extended:Z}")}\",\"msg\":\"hello world!\",\"level\":\"info\"}\n"
-    parsed = Poison.decode!(json)
-    assert Map.get(parsed, "msg") == "hello world!"
-    assert Map.get(parsed, "level") == "info"
+  test "formatting data, utc" do
+    ts = {{2001, 1, 2}, {3, 4, 5, 6}}
+
+    :ok = Application.put_env(:logger, :utc_log, true)
+    json = ExLogger.format(:info, "hello world", ts, [])
+
+    assert Poison.decode!(json) == %{
+             "ts" => "2001-01-02T03:04:05.006Z",
+             "msg" => "hello world",
+             "level" => "info"
+           }
+  end
+
+  test "formatting data, local time" do
+    ts = {{2001, 1, 2}, {3, 4, 5, 6}}
+
+    local_zone =
+      System.cmd("date", ["+%z"])
+      |> Tuple.to_list()
+      |> Enum.at(0)
+      |> String.split()
+      |> Enum.at(0)
+      |> String.to_charlist()
+      |> Enum.split(3)
+      |> Tuple.to_list()
+      |> Enum.join(":")
+
+    :ok = Application.put_env(:logger, :utc_log, false)
+    json = ExLogger.format(:info, "hello world", ts, [])
+
+    assert Poison.decode!(json) == %{
+             "ts" => "2001-01-02T03:04:05.006#{local_zone}",
+             "msg" => "hello world",
+             "level" => "info"
+           }
   end
 end

--- a/test/timestamp_formatter_test.exs
+++ b/test/timestamp_formatter_test.exs
@@ -1,0 +1,75 @@
+defmodule ExLogger.TimestampFormatterTest do
+  use ExUnit.Case
+
+  alias ExLogger.Formatter.Timestamp
+
+  test "test format timestamp" do
+    ts = {{2001, 1, 2}, {3, 4, 5, 6}}
+
+    assert Timestamp.format(ts, {0, 0}) == "2001-01-02T03:04:05.006Z"
+    assert Timestamp.format(ts, {5, 0}) == "2001-01-02T03:04:05.006+05:00"
+    assert Timestamp.format(ts, {15, 0}) == "2001-01-02T03:04:05.006+15:00"
+    assert Timestamp.format(ts, {5, 30}) == "2001-01-02T03:04:05.006+05:30"
+    assert Timestamp.format(ts, {-5, 0}) == "2001-01-02T03:04:05.006-05:00"
+    assert Timestamp.format(ts, {-15, 0}) == "2001-01-02T03:04:05.006-15:00"
+    assert Timestamp.format(ts, {-5, -30}) == "2001-01-02T03:04:05.006-05:30"
+  end
+
+  test "format 0 offset" do
+    assert Timestamp.format_offset({0, 0}) == "Z"
+  end
+
+  test "format positive offset" do
+    assert Timestamp.format_offset({1, 0}) == "+01:00"
+    assert Timestamp.format_offset({0, 30}) == "+00:30"
+    assert Timestamp.format_offset({10, 30}) == "+10:30"
+  end
+
+  test "format negative offset" do
+    assert Timestamp.format_offset({-1, 0}) == "-01:00"
+    assert Timestamp.format_offset({0, -30}) == "-00:30"
+    assert Timestamp.format_offset({-10, -30}) == "-10:30"
+  end
+
+  test "positive offset" do
+    utc = {{2019, 3, 8}, {15, 24, 36}}
+    local = {{2019, 3, 8}, {16, 54, 36}}
+
+    assert Timestamp.offset(utc, local) == {1, 30}
+  end
+
+  test "negative offset" do
+    utc = {{2019, 3, 8}, {16, 54, 36}}
+    local = {{2019, 3, 8}, {15, 24, 36}}
+
+    assert Timestamp.offset(utc, local) == {-1, -30}
+  end
+
+  test "positive date spanning offset" do
+    utc = {{2019, 3, 8}, {23, 54, 36}}
+    local = {{2019, 3, 9}, {01, 24, 36}}
+
+    assert Timestamp.offset(utc, local) == {1, 30}
+  end
+
+  test "positive date spanning offset hour only" do
+    utc = {{2019, 3, 8}, {23, 54, 36}}
+    local = {{2019, 3, 9}, {01, 54, 36}}
+
+    assert Timestamp.offset(utc, local) == {2, 0}
+  end
+
+  test "negative date spanning offset" do
+    utc = {{2019, 3, 9}, {01, 24, 36}}
+    local = {{2019, 3, 8}, {23, 55, 36}}
+
+    assert Timestamp.offset(utc, local) == {-1, -29}
+  end
+
+  test "negative date spanning offset hour only" do
+    utc = {{2019, 3, 9}, {01, 24, 36}}
+    local = {{2019, 3, 8}, {23, 24, 36}}
+
+    assert Timestamp.offset(utc, local) == {-2, 0}
+  end
+end


### PR DESCRIPTION
All timestamps sub second parts where prefixed with `000` due to microseconds vs milliseconds.

This PR also removes Timex dependency, and handles timezones :boom: 